### PR TITLE
updated fnalibs urls

### DIFF
--- a/getFNA.sh
+++ b/getFNA.sh
@@ -46,7 +46,7 @@ function getLibs()
 {
     # Downloading
     echo "Downloading latest fnalibs..."
-    curl http://fna.flibitijibibo.com/archive/fnalibs.tar.bz2 > "$MY_DIR/fnalibs.tar.bz2"
+    curl https://fna.flibitijibibo.com/archive/fnalibs.tar.bz2 > "$MY_DIR/fnalibs.tar.bz2"
     if [ $? -eq 0 ]; then
         echo "Finished downloading!"
     else

--- a/win_getFNA.ps1
+++ b/win_getFNA.ps1
@@ -47,7 +47,7 @@ function getLibs()
 {
     # Downloading
     Write-Output "Downloading latest fnalibs..."
-    Invoke-WebRequest -Uri http://fna.flibitijibibo.com/archive/fnalibs.tar.bz2 -OutFile $PSScriptRoot/fnalibs.tar.bz2
+    Invoke-WebRequest -Uri https://fna.flibitijibibo.com/archive/fnalibs.tar.bz2 -OutFile $PSScriptRoot/fnalibs.tar.bz2
     if ($?) {
         Write-Output "Finished downloading!"
     }


### PR DESCRIPTION
noticed while using one of the scripts that it failed at downloading fnalibs, this is due to the original download link being moved over from a http link over to an https link. this pull request just updates those links to use https instead of http in the download url. has been tested in macOS and works.

<img width="565" alt="image" src="https://github.com/TheSpydog/fna_vscode_template/assets/57515252/ac86c018-2770-49f3-a457-f304fe45ed7b">

<img width="682" alt="image" src="https://github.com/TheSpydog/fna_vscode_template/assets/57515252/8c8bedc9-c00e-408d-868b-5977202968cc">
